### PR TITLE
fix: Update RCO formation in db only if it has some changes

### DIFF
--- a/server/src/jobs/rcoImporter/importer/importer.js
+++ b/server/src/jobs/rcoImporter/importer/importer.js
@@ -195,8 +195,8 @@ class Importer {
             const key = keys[ite];
             updateInfo[key] = rcoFormationUpdated[key];
           }
+          toUpdateToDb.push({ rcoFormation, updateInfo, updates });
         }
-        toUpdateToDb.push({ rcoFormation, updateInfo, updates });
       } else {
         console.error(
           `updatedFormationsHandler >> Formation ${this._buildId(rcoFormationUpdated)} n'existe pas en base`


### PR DESCRIPTION
To prevent unnecessary db operations &  'null' updates in email report