### PR TITLE
feat: update importer

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -79,6 +79,7 @@
     "passport-local": "1.0.0",
     "require-all": "3.0.0",
     "sha512crypt-node": "0.1.0",
+    "string-similarity": "4.0.4",
     "swagger-jsdoc": "6.0.1",
     "swagger-ui-express": "4.1.6",
     "xlsx": "0.16.9"

--- a/server/src/jobs/oneshot/afFormation/index.js
+++ b/server/src/jobs/oneshot/afFormation/index.js
@@ -8,8 +8,10 @@ if (process.env.standalone) {
     logger.info(`Start affelnet import`);
 
     if ((await AfFormation.countDocuments({})) == 0) {
+      logger.info("Import des données en base");
       await seed();
     }
+    logger.info("Mise à jour des codes formation diplôme");
     await update(tableCorrespondance);
 
     logger.info(`End affelnet import`);

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -4060,6 +4060,11 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
+string-similarity@4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
+
 "string-width@^1.0.2 || 2":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"


### PR DESCRIPTION
92% de recouvrement des codes formations diplômes, trois méthodes : 

- Par le code MEF et les tables de correspondance
- Par le libellé de la formation et la table des formations converties (Algorithme _Indice de Sørensen-Dice_ - [npm](https://www.npmjs.com/package/string-similarity))
- Par le libellé de la formation et les tables de correspondance