### PR TITLE
perf(updater): spare calls to tco in updater

### DIFF
--- a/server/src/jobs/rcoConverter/converter/converter.js
+++ b/server/src/jobs/rcoConverter/converter/converter.js
@@ -147,7 +147,7 @@ const performConversion = async () => {
   const invalidRcoFormations = [];
   const convertedRcoFormations = [];
 
-  await paginator(RcoFormation, { filter: { converted_to_mna: { $ne: true } } }, async (rcoFormation) => {
+  await paginator(RcoFormation, { filter: { converted_to_mna: { $ne: true } }, limit: 10 }, async (rcoFormation) => {
     const mnaFormattedRcoFormation = formatToMnaFormation(rcoFormation._doc);
 
     if (!rcoFormation.published) {

--- a/server/src/jobs/trainingsUpdater/updater/updater.js
+++ b/server/src/jobs/trainingsUpdater/updater/updater.js
@@ -17,7 +17,7 @@ const performUpdates = async (filter = {}) => {
   const notUpdatedFormations = [];
   const updatedFormations = [];
 
-  await paginator(ConvertedFormation, { filter }, async (formation) => {
+  await paginator(ConvertedFormation, { filter, limit: 10 }, async (formation) => {
     const rcoFormation = await findRcoFormationFromConvertedId(formation.id_rco_formation);
     if (!rcoFormation?.published) {
       // if rco formation is not published, don't call mnaUpdater
@@ -26,7 +26,10 @@ const performUpdates = async (filter = {}) => {
       return;
     }
 
-    const { updates, formation: updatedFormation, error } = await mnaFormationUpdater(formation._doc);
+    const { updates, formation: updatedFormation, error } = await mnaFormationUpdater(formation._doc, {
+      // no need to check cp info in trainingsUpdater since it was successfully done once at converter
+      withCodePostalUpdate: false,
+    });
 
     if (error) {
       formation.update_error = error;

--- a/server/src/logic/mappers/etablissementsMapper.js
+++ b/server/src/logic/mappers/etablissementsMapper.js
@@ -1,6 +1,5 @@
 const logger = require("../../common/logger");
 const catalogue = require("../../common/components/catalogue");
-const { codePostalMapper } = require("./codePostalMapper");
 
 const getAttachedEstablishments = async (etablissement_gestionnaire_siret, etablissement_formateur_siret) => {
   // Get establishment Gestionnaire
@@ -85,63 +84,36 @@ const getGeoloc = ({ gestionnaire, formateur }) => {
 
 const mapEtablissementKeys = async (
   etablissement,
-  prefix = "etablissement_gestionnaire" || "etablissement_formateur",
-  cpMap = {}
+  prefix = "etablissement_gestionnaire" || "etablissement_formateur"
 ) => {
-  const { result: cpMapping, messages } =
-    cpMap[etablissement.code_postal] || (await codePostalMapper(etablissement.code_postal));
-
-  if (!cpMap[etablissement.code_postal]) {
-    cpMap[etablissement.code_postal] = { result: cpMapping, messages };
-  }
-
-  const {
-    code_postal = null,
-    code_commune_insee = null,
-    num_departement = null,
-    nom_departement = null,
-    region = null,
-    nom_academie = null,
-    num_academie = null,
-    localite = null,
-  } = cpMapping || {};
-
   return {
-    result: {
-      [`${prefix}_siren`]: etablissement.siren || null,
-      [`${prefix}_published`]: etablissement.published || false,
-      [`${prefix}_catalogue_published`]: etablissement.catalogue_published || false,
-      [`${prefix}_id`]: etablissement._id || null,
-      [`${prefix}_uai`]: etablissement.uai || null,
-      [`${prefix}_enseigne`]: etablissement.enseigne || null,
-      [`${prefix}_type`]: etablissement.computed_type || null,
-      [`${prefix}_conventionne`]: etablissement.computed_conventionne || null,
-      [`${prefix}_declare_prefecture`]: etablissement.computed_declare_prefecture || null,
-      [`${prefix}_datadock`]: etablissement.computed_info_datadock || null,
-      [`${prefix}_adresse`]: getEstablishmentAddress(etablissement),
-      [`${prefix}_complement_adresse`]: etablissement.complement_adresse || null,
-      [`${prefix}_cedex`]: etablissement.cedex || null,
-      [`${prefix}_entreprise_raison_sociale`]: etablissement.entreprise_raison_sociale || null,
+    [`${prefix}_siren`]: etablissement.siren || null,
+    [`${prefix}_published`]: etablissement.published || false,
+    [`${prefix}_catalogue_published`]: etablissement.catalogue_published || false,
+    [`${prefix}_id`]: etablissement._id || null,
+    [`${prefix}_uai`]: etablissement.uai || null,
+    [`${prefix}_enseigne`]: etablissement.enseigne || null,
+    [`${prefix}_type`]: etablissement.computed_type || null,
+    [`${prefix}_conventionne`]: etablissement.computed_conventionne || null,
+    [`${prefix}_declare_prefecture`]: etablissement.computed_declare_prefecture || null,
+    [`${prefix}_datadock`]: etablissement.computed_info_datadock || null,
+    [`${prefix}_adresse`]: getEstablishmentAddress(etablissement),
+    [`${prefix}_complement_adresse`]: etablissement.complement_adresse || null,
+    [`${prefix}_cedex`]: etablissement.cedex || null,
+    [`${prefix}_entreprise_raison_sociale`]: etablissement.entreprise_raison_sociale || null,
 
-      [`${prefix}_code_postal`]: code_postal,
-      [`${prefix}_code_commune_insee`]: code_commune_insee,
-      [`${prefix}_num_departement`]: num_departement,
-      [`${prefix}_nom_departement`]: nom_departement,
-      [`${prefix}_region`]: region,
-      [`${prefix}_nom_academie`]: nom_academie,
-      [`${prefix}_num_academie`]: num_academie,
-      [`${prefix}_localite`]: localite,
-    },
-    messages,
+    [`${prefix}_code_postal`]: etablissement.code_postal || null,
+    [`${prefix}_code_commune_insee`]: etablissement.code_insee_localite || null,
+    [`${prefix}_num_departement`]: etablissement.num_departement || null,
+    [`${prefix}_nom_departement`]: etablissement.nom_departement || null,
+    [`${prefix}_region`]: etablissement.region_implantation_nom || null,
+    [`${prefix}_nom_academie`]: etablissement.nom_academie || null,
+    [`${prefix}_num_academie`]: etablissement.num_academie ? `${etablissement.num_academie}` : null,
+    [`${prefix}_localite`]: etablissement.localite || null,
   };
 };
 
-const etablissementsMapper = async (
-  etablissement_gestionnaire_siret,
-  etablissement_formateur_siret,
-  cpMap = {},
-  rncpInfo
-) => {
+const etablissementsMapper = async (etablissement_gestionnaire_siret, etablissement_formateur_siret, rncpInfo) => {
   try {
     if (!etablissement_gestionnaire_siret && !etablissement_formateur_siret) {
       throw new Error("etablissementsMapper gestionnaire_siret, formateur_siret  must be provided");
@@ -159,15 +131,14 @@ const etablissementsMapper = async (
 
     const { referenceEstablishment, etablissement_reference } = etablissementReference;
 
-    const {
-      result: etablissementGestionnaire,
-      messages: etablissementGestionnaireMessages,
-    } = await mapEtablissementKeys(attachedEstablishments.gestionnaire || {}, "etablissement_gestionnaire", cpMap);
+    const etablissementGestionnaire = await mapEtablissementKeys(
+      attachedEstablishments.gestionnaire || {},
+      "etablissement_gestionnaire"
+    );
 
-    const { result: etablissementFormateur, messages: etablissementFormateurMessages } = await mapEtablissementKeys(
+    const etablissementFormateur = await mapEtablissementKeys(
       attachedEstablishments.formateur || {},
-      "etablissement_formateur",
-      cpMap
+      "etablissement_formateur"
     );
 
     const geolocInfo = getGeoloc(attachedEstablishments);
@@ -190,7 +161,6 @@ const etablissementsMapper = async (
 
         ...geolocInfo,
       },
-      messages: { ...etablissementGestionnaireMessages, ...etablissementFormateurMessages },
     };
   } catch (e) {
     logger.error(e);

--- a/server/src/logic/updaters/mnaFormationUpdater.js
+++ b/server/src/logic/updaters/mnaFormationUpdater.js
@@ -33,7 +33,7 @@ const parseErrors = (messages) => {
     .reduce((acc, [key, value]) => `${acc}${acc ? " " : ""}${key}: ${value}.`, "");
 };
 
-const mnaFormationUpdater = async (formation, { withHistoryUpdate = true } = {}) => {
+const mnaFormationUpdater = async (formation, { withHistoryUpdate = true, withCodePostalUpdate = true } = {}) => {
   try {
     await formationSchema.validateAsync(formation, { abortEarly: false });
 
@@ -44,7 +44,9 @@ const mnaFormationUpdater = async (formation, { withHistoryUpdate = true } = {})
       return { updates: null, formation, error };
     }
 
-    const { result: cpMapping, messages: cpMessages } = await codePostalMapper(formation.code_postal);
+    const { result: cpMapping = {}, messages: cpMessages } = withCodePostalUpdate
+      ? await codePostalMapper(formation.code_postal)
+      : {};
     error = parseErrors(cpMessages);
     if (error) {
       return { updates: null, formation, error };
@@ -56,11 +58,9 @@ const mnaFormationUpdater = async (formation, { withHistoryUpdate = true } = {})
       rncp_eligible_apprentissage: cfdMapping?.rncp_eligible_apprentissage,
       ...cfdMapping?.rncp_details,
     };
-    const cachedCpResult = { [formation.code_postal]: { result: cpMapping, messages: cpMessages } };
     const { result: etablissementsMapping, messages: etablissementsMessages } = await etablissementsMapper(
       formation.etablissement_gestionnaire_siret,
       formation.etablissement_formateur_siret,
-      cachedCpResult,
       rncpInfo
     );
 


### PR DESCRIPTION
Remove uselless calls to code postal api + limit paginate to 10 items per batch

:warning: Il manque le **nom_departement** dans les établissements provenant des tables de correspondances. Pas très grave pour le moment vu qu'on ne l'utilise pas en front sur le catalogue, mais peut être que les clients de l'api catalogue en ont besoin.