### PR TITLE
perf(api): faster & lighter formations API

### DIFF
--- a/server/src/http/routes/convertedFormation.js
+++ b/server/src/http/routes/convertedFormation.js
@@ -81,7 +81,12 @@ module.exports = () => {
       const page = qs && qs.page ? qs.page : 1;
       const limit = qs && qs.limit ? parseInt(qs.limit, 10) : 10;
 
-      const allData = await ConvertedFormation.paginate(query, { page, limit });
+      const allData = await ConvertedFormation.paginate(query, {
+        page,
+        limit,
+        lean: true,
+        select: { updates_history: 0, __v: 0 },
+      });
       return res.json({
         formations: allData.docs,
         pagination: {
@@ -118,7 +123,7 @@ module.exports = () => {
     tryCatch(async (req, res) => {
       let qs = req.query;
       const query = qs && qs.query ? JSON.parse(qs.query) : {};
-      const retrievedData = await ConvertedFormation.findOne(query);
+      const retrievedData = await ConvertedFormation.findOne(query, { updates_history: 0, __v: 0 }).lean();
       if (retrievedData) {
         return res.json(retrievedData);
       }
@@ -133,7 +138,7 @@ module.exports = () => {
     "/formation2021/:id",
     tryCatch(async (req, res) => {
       const itemId = req.params.id;
-      const retrievedData = await ConvertedFormation.findById(itemId);
+      const retrievedData = await ConvertedFormation.findById(itemId, { updates_history: 0, __v: 0 }).lean();
       if (retrievedData) {
         return res.json(retrievedData);
       }


### PR DESCRIPTION
En ne retournant pas l'`updates_history`, on divise la payload retournée par 2 ~. 
En utilisant le `lean()` on gagne en mémoire et en perf.