### PR TITLE
feat(api): add id_parcoursup query param

### DIFF
--- a/server/src/http/routes/convertedFormation.js
+++ b/server/src/http/routes/convertedFormation.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const tryCatch = require("../middlewares/tryCatchMiddleware");
-const { ConvertedFormation } = require("../../common/model");
+const { ConvertedFormation, PsFormation2021 } = require("../../common/model");
 const { mnaFormationUpdater } = require("../../logic/updaters/mnaFormationUpdater");
 
 /**
@@ -95,6 +95,19 @@ module.exports = () => {
 
       const query = cleanedQuery ? JSON.parse(cleanedQuery) : {};
 
+      const { id_parcoursup, ...filter } = query;
+      // additional filtering for parcoursup
+      if (id_parcoursup) {
+        const psFormations = await PsFormation2021.find(
+          { id_parcoursup, matching_mna_formation: { $size: 1 } },
+          { matching_mna_formation: 1 }
+        ).lean();
+        const ids = psFormations.reduce((acc, { matching_mna_formation }) => {
+          return [...acc, ...matching_mna_formation.map(({ _id }) => _id)];
+        }, []);
+        filter["_id"] = { $in: ids };
+      }
+
       const page = qs && qs.page ? qs.page : 1;
       const limit = qs && qs.limit ? parseInt(qs.limit, 10) : 10;
       const select =
@@ -102,7 +115,7 @@ module.exports = () => {
           ? JSON.parse(qs.select)
           : { affelnet_statut_history: 0, parcoursup_statut_history: 0, updates_history: 0, __v: 0 };
 
-      const allData = await ConvertedFormation.paginate(query, {
+      const allData = await ConvertedFormation.paginate(filter, {
         page,
         limit,
         lean: true,


### PR DESCRIPTION
Ajout d'un paramètre de requête pour l'API des formations, afin de filtrer par `id_parcoursup`. La fonctionnalité est à destination de l'application "Prise de rendez-vous".

eg: `/api/entity/formations2021?query={"id_parcoursup":26969}`

EDIT / Je renvoie à présent uniquement les formations pour lesquelles on a une seule occurrence par id parcoursup (1 pour 1 match fort) 