### PR TITLE
feat(affelnet): reset reconciliation auto before running it

### DIFF
--- a/server/src/jobs/affelnet/reconciliation.js
+++ b/server/src/jobs/affelnet/reconciliation.js
@@ -1,6 +1,6 @@
 const { reconciliationAffelnet } = require("../../logic/controller/reconciliation");
 const { paginator } = require("../common/utils/paginator");
-const { AfFormation /*, AfReconciliation */ } = require("../../common/model");
+const { AfFormation, AfReconciliation } = require("../../common/model");
 const { runScript } = require("../scriptWrapper");
 const logger = require("../../common/logger");
 
@@ -8,8 +8,7 @@ const afReconciliation = async () => {
   try {
     logger.info(`Start affelnet reconciliation`);
 
-    // FIXME: hotfix to be removed once reconciliation is fixed
-    // await AfReconciliation.deleteMany({ source: { $in: [null, "AUTOMATIQUE"] } });
+    await AfReconciliation.deleteMany({ source: { $in: [null, "AUTOMATIQUE"] } });
 
     await paginator(
       AfFormation,

--- a/server/src/jobs/index.js
+++ b/server/src/jobs/index.js
@@ -52,7 +52,7 @@ runScript(async ({ catalogue, db }) => {
     await psPertinence(); // ~ 8 secondes
 
     // affelnet
-    await afCoverage();
+    await afCoverage(); // ~ 47 minutes => ~ 12 minutes
     await afReconciliation();
     await afReference(); // ~ 50 minutes => ~ 5 minutes
     await afPertinence();


### PR DESCRIPTION
:warning: cela va impacter 494 formations "publié" Affelnet, et les passer en "à publier" ou "à publier (soumis à validation)".
Les académies vont être prévenues :
https://docs.google.com/spreadsheets/d/1408mdb7RG2MwqhjBPIpEZqCsfZtTh1dSXU9OZNtpuyM/edit?usp=sharing