### PR TITLE
feat(affelnet): check cfd expiracy in pertinence rules

### DIFF
--- a/server/src/jobs/pertinence/affelnet/rules.js
+++ b/server/src/jobs/pertinence/affelnet/rules.js
@@ -1,5 +1,13 @@
 const { toBePublishedRules } = require("../../common/utils/referenceUtils");
 
+const getCfdExpireRule = (duration) => {
+  const currentYear = new Date().getFullYear();
+  const limitYear = currentYear + duration - 1;
+  return {
+    $or: [{ cfd_date_fermeture: { $gt: new Date(`${limitYear}-12-31T00:00:00.000Z`) } }, { cfd_date_fermeture: null }],
+  };
+};
+
 const getMefRule = (...args) => {
   const rule = args.reduce((acc, regex) => {
     return [...acc, { mef_10_code: { $regex: regex } }, { "bcn_mefs_10.mef10": { $regex: regex } }];
@@ -17,51 +25,51 @@ const aPublierSoumisAValidationRules = {
           $or: [
             {
               ...getMefRule(/11$/),
-              $and: [getMefRule(/^240/)],
+              $and: [getMefRule(/^240/), getCfdExpireRule(1)],
             },
             {
               ...getMefRule(/31$/),
-              $and: [getMefRule(/^242/)],
+              $and: [getMefRule(/^242/), getCfdExpireRule(3)],
             },
           ],
         },
         {
           diplome: "BAC PROFESSIONNEL",
           ...getMefRule(/21$/),
-          $and: [getMefRule(/^246/)],
+          $and: [getMefRule(/^246/), getCfdExpireRule(2)],
         },
         {
           diplome: "BAC PROFESSIONNEL AGRICOLE",
           ...getMefRule(/21$/),
-          $and: [getMefRule(/^273/)],
+          $and: [getMefRule(/^273/), getCfdExpireRule(2)],
         },
 
         {
           diplome: "BREVET PROFESSIONNEL",
           ...getMefRule(/21$/),
-          $and: [getMefRule(/^254/)],
+          $and: [getMefRule(/^254/), getCfdExpireRule(2)],
         },
         {
           diplome: "BREVET PROFESSIONNEL AGRICOLE",
           ...getMefRule(/21$/),
-          $and: [getMefRule(/^254/)],
+          $and: [getMefRule(/^254/), getCfdExpireRule(2)],
         },
         {
           diplome: "BREVET DES METIERS D'ART - BREVET DES METIERS DU SPECTACLE",
           ...getMefRule(/21$/),
-          $and: [getMefRule(/^251/)],
+          $and: [getMefRule(/^251/), getCfdExpireRule(2)],
         },
         {
           diplome: "MENTION COMPLEMENTAIRE",
           niveau: "3 (CAP...)",
           ...getMefRule(/11$/),
-          $and: [getMefRule(/^253/)],
+          $and: [getMefRule(/^253/), getCfdExpireRule(1)],
         },
         {
           diplome: "MENTION COMPLEMENTAIRE AGRICOLE",
           niveau: "3 (CAP...)",
           ...getMefRule(/11$/),
-          $and: [getMefRule(/^274/)],
+          $and: [getMefRule(/^274/), getCfdExpireRule(1)],
         },
       ],
     },
@@ -79,22 +87,22 @@ const aPublierRules = {
         {
           diplome: "CERTIFICAT D'APTITUDES PROFESSIONNELLES",
           ...getMefRule(/21$/),
-          $and: [getMefRule(/^241/)],
+          $and: [getMefRule(/^241/), getCfdExpireRule(2)],
         },
         {
           diplome: "CERTIFICAT D'APTITUDES PROFESSIONNELLES AGRICOLES",
           ...getMefRule(/21$/),
-          $and: [getMefRule(/^271/)],
+          $and: [getMefRule(/^271/), getCfdExpireRule(2)],
         },
         {
           diplome: "BAC PROFESSIONNEL",
           ...getMefRule(/31$/),
-          $and: [getMefRule(/^247/)],
+          $and: [getMefRule(/^247/), getCfdExpireRule(3)],
         },
         {
           diplome: "BAC PROFESSIONNEL AGRICOLE",
           ...getMefRule(/31$/),
-          $and: [getMefRule(/^276/)],
+          $and: [getMefRule(/^276/), getCfdExpireRule(3)],
         },
       ],
     },


### PR DESCRIPTION
voilà ce que ça donne avec les données de prod du 03/06/2021  (avant --> après):
```
Total formations hors périmètre : 17720/29181 --> 17773/29181 (+53)
Total formations à publier (soumis à validation) : 1266/29181 --> 1556/29181 (+290)
Total formations à publier : 3010/29181 --> 2667/29181  (-343)
Total formations en attente de publication : 974/29181 --> idem
Total formations publiées sur Affelnet : 4889/29181 --> idem
Total formations NON publiées sur Affelnet : 1322/29181 --> idem
```
On a moins de "à publier" (normal) et plus de "soumis à validation" et de hors périmètre. Ça me semble vraiment pas mal :slightly_smiling_face: 