### PR TITLE
Feature/reconciliation lab

### DIFF
--- a/server/src/common/model/schema/afReconciliation.js
+++ b/server/src/common/model/schema/afReconciliation.js
@@ -30,6 +30,11 @@ const afReconciliationSchema = {
     enum: ["MANUEL", "AUTOMATIQUE"],
     description: "Auteur de la réconciliation (MANUEL : par un utilisateur depuis l'interface / AUTO : par script)",
   },
+  code_postal: {
+    type: String,
+    default: null,
+    description: "code postal de la formation du catalogue",
+  },
 };
 
 module.exports = afReconciliationSchema;

--- a/server/src/http/routes/affelnet.js
+++ b/server/src/http/routes/affelnet.js
@@ -92,7 +92,7 @@ module.exports = ({ catalogue }) => {
   router.post(
     "/reconciliation",
     tryCatch(async (req, res) => {
-      const { mapping, id_formation, ...rest } = req.body;
+      const { mapping, id_formation, code_postal, ...rest } = req.body;
       const reconciliation = combinate(mapping);
 
       let payload = reconciliation.reduce((acc, item) => {
@@ -105,7 +105,11 @@ module.exports = ({ catalogue }) => {
 
       let { code_cfd, uai } = payload;
 
-      const result = await AfReconciliation.findOneAndUpdate({ code_cfd, uai }, payload, { upsert: true, new: true });
+      const result = await AfReconciliation.findOneAndUpdate(
+        { code_cfd, uai },
+        { ...payload, code_postal },
+        { upsert: true, new: true }
+      );
 
       if (result) {
         await AfFormation.findByIdAndUpdate(id_formation, { etat_reconciliation: true });

--- a/server/src/jobs/affelnet/reconciliation.js
+++ b/server/src/jobs/affelnet/reconciliation.js
@@ -12,7 +12,7 @@ const afReconciliation = async () => {
 
     await paginator(
       AfFormation,
-      { filter: { matching_mna_formation: { $size: 1 } }, lean: true, limit: 200 },
+      { filter: { matching_mna_formation: { $size: 1 }, matching_type: "3" }, lean: true, limit: 200 },
       async (formation) => await reconciliationAffelnet(formation, "AUTOMATIQUE")
     );
 

--- a/server/src/jobs/affelnet/reconciliation.js
+++ b/server/src/jobs/affelnet/reconciliation.js
@@ -10,9 +10,43 @@ const afReconciliation = async () => {
 
     await AfReconciliation.deleteMany({ source: { $in: [null, "AUTOMATIQUE"] } });
 
+    const duplicates = await AfFormation.aggregate([
+      { $match: { matching_mna_formation: { $size: 1 } } },
+      {
+        $unwind: "$matching_mna_formation",
+      },
+      {
+        $group: {
+          _id: "$_id",
+          mna: {
+            $first: "$matching_mna_formation",
+          },
+        },
+      },
+      {
+        $group: {
+          _id: "$mna._id",
+          count: { $sum: 1 },
+        },
+      },
+      { $match: { count: { $gte: 2 } } },
+      { $sort: { count: -1 } },
+    ]);
+
+    console.log(`found ${duplicates.length} duplicates`);
+    const excludedIds = duplicates.map(({ _id }) => _id);
+
     await paginator(
       AfFormation,
-      { filter: { matching_mna_formation: { $size: 1 }, matching_type: "3" }, lean: true, limit: 200 },
+      {
+        filter: {
+          matching_mna_formation: { $size: 1 },
+          matching_type: "3",
+          "matching_mna_formation._id": { $nin: excludedIds },
+        },
+        lean: true,
+        limit: 200,
+      },
       async (formation) => await reconciliationAffelnet(formation, "AUTOMATIQUE")
     );
 

--- a/server/src/jobs/reference/affelnet/controller.js
+++ b/server/src/jobs/reference/affelnet/controller.js
@@ -19,6 +19,7 @@ const run = async () => {
         cfd_outdated: { $ne: true },
         mefs_10: { $ne: null },
         niveau: { $in: ["3 (CAP...)", "4 (Bac...)"] },
+        code_postal: reconciliation.code_postal,
         $or: [
           {
             cfd: reconciliation.code_cfd,

--- a/server/src/logic/controller/reconciliation.js
+++ b/server/src/logic/controller/reconciliation.js
@@ -18,7 +18,12 @@ async function reconciliationAffelnet(formation, source = "MANUEL") {
     libelle_mnemonique,
   } = formation;
 
-  let { etablissement_formateur_siret, etablissement_gestionnaire_siret, _id: convertedId } = matching_mna_formation[0];
+  let {
+    etablissement_formateur_siret,
+    etablissement_gestionnaire_siret,
+    code_postal,
+    _id: convertedId,
+  } = matching_mna_formation[0];
 
   if (!uai) {
     await AfFormation.findByIdAndUpdate(_id, {
@@ -36,7 +41,7 @@ async function reconciliationAffelnet(formation, source = "MANUEL") {
     source,
   };
 
-  await AfReconciliation.findOneAndUpdate({ uai, code_cfd }, payload, { upsert: true });
+  await AfReconciliation.findOneAndUpdate({ uai, code_cfd, code_postal }, payload, { upsert: true });
 
   await AfFormation.findByIdAndUpdate(_id, {
     etat_reconciliation: true,

--- a/ui/src/pages/reconciliation-affelnet/components/Accordion.js
+++ b/ui/src/pages/reconciliation-affelnet/components/Accordion.js
@@ -76,6 +76,7 @@ export default ({ data }) => {
         id_formation: data._id,
         uai: data.uai,
         code_cfd: data.code_cfd,
+        code_postal: data.code_postal,
         mapping: mapping,
       }),
     {


### PR DESCRIPTION
:biohazard: Draft car ce sont des expérimentations dont l'impact sur le périmètre Affelnet est important :biohazard: 

:lab_coat: J'ai fait plusieurs expériences, en partant de mes données locales :
```
avant : 3565 réconciliations --> Total formations publiées sur Affelnet : 3419/26316
```

1ere expérience sur la reconciliation Affelnet, le matching 3 étoiles seulement. Sur mes données en local ça donne :
```
2357 réconciliations --> Total formations publiées sur Affelnet : 2473/26316
```
OK ça semble bien de garder que le match de niveau 3+ :green_circle: 

2e expérience, l'ajout du test sur le code postal pour la reference (en plus de siret et du cfd) :
```
3565 réconciliations --> Total formations publiées sur Affelnet : 3069/26316
```
NOPE ça semble un mauvaise idée car le cp peut changer. :red_square: 

Expérience numéro 3, contrôler qu'on a que 1 formation Affelnet qui matche pour 1 formation du catalogue :
(en local 252 formations du catalogue se retrouvent dans plusieurs formations Affelnet en match unique)
```
3057 réconciliations --> Total formations publiées sur Affelnet : 3203/26316
```
OK à tester ça semble plus fiable, à tester  :green_circle: 

:gift: Bonus : Toutes les expériences en même temps :
```
2193 réconciliations ---> Total formations publiées sur Affelnet : 2008/26316
```