### PR TITLE
fix(rapprochement): reset older convertedFormation publiée

### DIFF
--- a/server/src/jobs/parcoursup/miscJobs/_cleanMnaFStatus.js
+++ b/server/src/jobs/parcoursup/miscJobs/_cleanMnaFStatus.js
@@ -48,4 +48,8 @@ async function update() {
       );
     }
   });
+  await ConvertedFormation.updateMany(
+    { parcoursup_statut: "publié", published: true },
+    { $set: { parcoursup_statut: "hors périmètre", parcoursup_reference: false } }
+  );
 }


### PR DESCRIPTION
Pour résoudre  le problème des anciennes réconciliations versus le nouvel import.
Entre les formations PS “Juin-2021” et “Octobre 2021"
il y a des formations qui ont disparus mais de notre coté mais qui ont été rapprochées en Juillet.
Le script reset utilise les formations Ps-Octobre-2021 donc il y a un gap