### PR TITLE
fix: hide not selectable fields from swagger doc

### DIFF
--- a/server/src/common/model/swaggerSchema/formation.js
+++ b/server/src/common/model/swaggerSchema/formation.js
@@ -503,11 +503,6 @@ module.exports = {
         default: "null",
         description: "Année de la formation (cursus)",
       },
-      email: {
-        type: "string",
-        default: "null",
-        description: "Email du contact pour cette formation",
-      },
       parcoursup_reference: {
         type: "boolean",
         default: false,
@@ -543,12 +538,9 @@ module.exports = {
         default: "null",
         description: "Erreur lors du contrôle de référencement sur ParcourSup de la formation",
       },
-      parcoursup_ids: {
-        type: "array",
-        items: {
-          type: "string",
-        },
-        default: [],
+      parcoursup_id: {
+        type: "string",
+        default: "null",
         description: "ids ParcourSup",
       },
       affelnet_reference: {

--- a/server/src/jobs/generateSwaggerSchema/index.js
+++ b/server/src/jobs/generateSwaggerSchema/index.js
@@ -7,14 +7,15 @@ const schemas = require("../../common/model/schema");
 
 const { Schema } = mongoose;
 
-// Should not be use, issue https://github.com/deliveryhero/serverless-aws-documentation/blob/master/src/models.js#L9
-const replaceNullDefault = (schem) => {
-  const obj = { ...schem };
-  // eslint-disable-next-line no-restricted-syntax
+const cleanSchema = (schema) => {
+  const obj = { ...schema };
   for (const key of Object.keys(obj)) {
-    // eslint-disable-next-line no-prototype-builtins
-    if (obj[key].hasOwnProperty("default") && obj[key].default === null) {
+    if (obj[key]?.default === null) {
       obj[key].default = "null";
+    }
+
+    if (obj[key].select === false) {
+      delete obj[key];
     }
   }
   return obj;
@@ -24,7 +25,7 @@ Object.keys(schemas).forEach((schemaName) => {
   if (schemaName === "formationSchema") {
     const schema = schemas[schemaName];
     const baseFilename = schemaName.replace("Schema", "");
-    const eSchema = new Schema(replaceNullDefault(schema));
+    const eSchema = new Schema(cleanSchema(schema));
     const eJsonSchema = eSchema.jsonSchema();
     let sout = {};
     sout[baseFilename] = eJsonSchema;


### PR DESCRIPTION
Prevent sensible fields from being documented on api doc