### PR TITLE
Fix issue with node_modules overwritten by volume in devevelopment

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,7 +6,6 @@ services:
       - catalogue_apprentissage_nginx_data:/data:z
 
   ui:
-    command: yarn start
     mem_limit: 1g
     stdin_open: true
     volumes:

--- a/ui/Dockerfile.dev
+++ b/ui/Dockerfile.dev
@@ -16,11 +16,6 @@ ENV REACT_APP_METABASE_SECRET_KEY=$REACT_APP_METABASE_SECRET_KEY
 
 WORKDIR /app
 
-COPY package.json yarn.lock ./
-
-RUN yarn install --frozen-lockfile
-
-COPY ./ /app
-
 EXPOSE 3000
-CMD yarn start
+
+CMD yarn install && yarn start


### PR DESCRIPTION
In Dockerfile.dev, execute yarn install in CMD instead of RUN as node…_modules is overwritten by a volume