### PR TITLE
bugfix: Ajout de la colonne 'A des formations n3' dans l'export des organismes

### DIFF
--- a/ui/src/common/components/Search/constantsEtablissements.js
+++ b/ui/src/common/components/Search/constantsEtablissements.js
@@ -159,37 +159,7 @@ const columnsDefinition = [
     Header: "A des formations de niveau 3",
     accessor: "formations_n3",
     width: 200,
-    exportable: false,
-  },
-  {
-    Header: "A des formations de niveau 4",
-    accessor: "formations_n4",
-    width: 200,
-    exportable: false,
-  },
-  {
-    Header: "A des formations de niveau 5",
-    accessor: "formations_n5",
-    width: 200,
-    exportable: false,
-  },
-  {
-    Header: "A des formations de niveau 6",
-    accessor: "formations_n6",
-    width: 200,
-    exportable: false,
-  },
-  {
-    Header: "A des formations de niveau 7",
-    accessor: "formations_n7",
-    width: 200,
-    exportable: false,
-  },
-  {
-    Header: "A des formations de niveau 3",
-    accessor: "formations_n3",
-    width: 200,
-    exportable: false,
+    exportable: true,
   },
   {
     Header: "A des formations de niveau 4",


### PR DESCRIPTION
https://trello.com/c/YFYgVWnE/919-lexport-des-organismes-ne-comporte-pas-la-colonne-a-des-formations-de-niveau-3