### PR TITLE
feat: clean status history PS

### DIFF
--- a/server/migrations/20220210162942-clean-parcoursup-formation-statuts-history.js
+++ b/server/migrations/20220210162942-clean-parcoursup-formation-statuts-history.js
@@ -1,0 +1,11 @@
+module.exports = {
+  async up(db) {
+    const collection = db.collection("parcoursupformations");
+    await collection.updateMany({}, { $unset: { statuts_history: 1 } });
+  },
+
+  async down() {
+    // can't restore previous state
+    return Promise.resolve("ok");
+  },
+};

--- a/server/src/common/model/schema/parcoursupFormation.js
+++ b/server/src/common/model/schema/parcoursupFormation.js
@@ -161,12 +161,6 @@ const parcoursupFormationSchema = {
     default: null,
     description: "Details raison autre rejet",
   },
-  statuts_history: {
-    type: [Object],
-    default: [],
-    description: "historique des statuts",
-    noIndex: true,
-  },
   id_parcoursup: {
     index: true,
     type: String,

--- a/server/src/jobs/parcoursup/reportRejected.js
+++ b/server/src/jobs/parcoursup/reportRejected.js
@@ -41,7 +41,6 @@ const reportRejected = async () => {
         etat_reconciliation,
         statut_reconciliation,
         matching_rejete_updated,
-        statuts_history,
         matching_type,
         __v,
         _id,

--- a/server/src/logic/common/utils/diffUtils.js
+++ b/server/src/logic/common/utils/diffUtils.js
@@ -34,18 +34,11 @@ const diffFormation = (previousFormationP, nextFormationP) => {
 /*
  * Build updates history
  */
-const buildUpdatesHistory = (formation, updates, keys, source, psFormation = false) => {
+const buildUpdatesHistory = (formation, updates, keys, source) => {
   const from = keys.reduce((acc, key) => {
     acc[key] = formation[key];
     return acc;
   }, {});
-
-  if (psFormation) {
-    return [
-      ...(formation.statuts_history || []),
-      { from, to: { ...updates }, updated_at: Date.now(), ...(source ? { source } : {}) },
-    ];
-  }
 
   return [
     ...formation.updates_history,

--- a/server/src/logic/updaters/coverageUpdater.js
+++ b/server/src/logic/updaters/coverageUpdater.js
@@ -1,4 +1,3 @@
-const { diffFormation, buildUpdatesHistory } = require("../../logic/common/utils/diffUtils");
 const { ParcoursupFormation } = require("../../common/model");
 const { getParcoursupCoverage } = require("../../logic/controller/coverage");
 
@@ -27,15 +26,6 @@ const updateMatchedFormation = async ({ formation: previousFormation, match }) =
 
   if (statut_reconciliation === "AUTOMATIQUE") {
     updatedFormation.etat_reconciliation = true;
-  }
-
-  // History
-  const { updates, keys } = diffFormation(previousFormation, updatedFormation);
-  if (updates) {
-    delete updates.matching_mna_formation;
-    const statuts_history = buildUpdatesHistory(previousFormation, updates, keys, null, true);
-
-    updatedFormation.statuts_history = statuts_history;
   }
 
   await ParcoursupFormation.findByIdAndUpdate(updatedFormation._id, updatedFormation, {

--- a/ui/src/pages/admin/ReconciliationPs/ReconciliationPs.test.js
+++ b/ui/src/pages/admin/ReconciliationPs/ReconciliationPs.test.js
@@ -462,7 +462,6 @@ test("opens rapprochement modal", async () => {
       statut_reconciliation: "AUTOMATIQUE",
       matching_rejete_updated: false,
       matching_rejete_raison: null,
-      statuts_history: [],
       id_parcoursup: "33639",
       uai_cerfa: "0441975H",
       uai_insert_jeune: "0441975H",


### PR DESCRIPTION
Suppression de l'historique des rapprochements Parcoursup, et enregistrement des annulations de rapprochements validés dans l'historique des formations.

https://trello.com/c/3AP3zvY8/936-clean-données-dhistorisation-à-supprimer-ne-plus-stocker-historique-des-rapprochements-parcoursup