### PR TITLE
Feature/history status affelnet parcoursup

### DIFF
--- a/server/migrations/20220215110549-limit-history-affelnet-parcoursup.js
+++ b/server/migrations/20220215110549-limit-history-affelnet-parcoursup.js
@@ -1,0 +1,27 @@
+module.exports = {
+  async up(db) {
+    const collection = db.collection("formations");
+
+    // keep only the last 100 entries in history
+    await collection.updateMany(
+      {},
+      {
+        $push: {
+          affelnet_statut_history: {
+            $each: [],
+            $slice: -100,
+          },
+          parcoursup_statut_history: {
+            $each: [],
+            $slice: -100,
+          },
+        },
+      }
+    );
+  },
+
+  async down() {
+    // can't restore previous state
+    return Promise.resolve("ok");
+  },
+};

--- a/server/src/logic/updaters/tagsHistoryUpdater.js
+++ b/server/src/logic/updaters/tagsHistoryUpdater.js
@@ -1,5 +1,7 @@
 const { Formation } = require("../../common/model/index");
 
+const KEEP_HISTORY_DAYS_LIMIT = 100;
+
 const updateTagsHistory = async (scope) => {
   await Formation.updateMany(
     { [`${scope}_history`]: null },
@@ -18,6 +20,19 @@ const updateTagsHistory = async (scope) => {
       },
     },
   ]);
+
+  // keep only the last N entries in history
+  await Formation.updateMany(
+    {},
+    {
+      $push: {
+        [`${scope}_history`]: {
+          $each: [],
+          $slice: -KEEP_HISTORY_DAYS_LIMIT,
+        },
+      },
+    }
+  );
 };
 
 module.exports = { updateTagsHistory };


### PR DESCRIPTION
https://trello.com/c/lhsTqJlY/940-clean-données-dhistorisation-garder-3-mois-dhistorique-de-changement-détiquette-affelnet-parcoursup

Évolution pour garder 3 mois d'historique de changement des étiquettes Affelnet & Parcoursup