### PR TITLE
fix: keep 200 items in status history

### DIFF
--- a/server/migrations/20220215110549-limit-history-affelnet-parcoursup.js
+++ b/server/migrations/20220215110549-limit-history-affelnet-parcoursup.js
@@ -2,18 +2,18 @@ module.exports = {
   async up(db) {
     const collection = db.collection("formations");
 
-    // keep only the last 100 entries in history
+    // keep only the last 200 entries in history (a bit more than 6 month)
     await collection.updateMany(
       {},
       {
         $push: {
           affelnet_statut_history: {
             $each: [],
-            $slice: -100,
+            $slice: -200,
           },
           parcoursup_statut_history: {
             $each: [],
-            $slice: -100,
+            $slice: -200,
           },
         },
       }

--- a/server/src/logic/updaters/tagsHistoryUpdater.js
+++ b/server/src/logic/updaters/tagsHistoryUpdater.js
@@ -1,6 +1,7 @@
 const { Formation } = require("../../common/model/index");
 
-const KEEP_HISTORY_DAYS_LIMIT = 100;
+// keep 200 days in history (a bit more than 6 month)
+const KEEP_HISTORY_DAYS_LIMIT = 200;
 
 const updateTagsHistory = async (scope) => {
   await Formation.updateMany(


### PR DESCRIPTION
200 éléments pour être sûr de couvrir la campagne affelnet (5-6 mois)