### PR TITLE
Feature/remove archived rco training after 1 year

### DIFF
--- a/server/migrations/20220215135326-limit-rcoformation-updates-history.js
+++ b/server/migrations/20220215135326-limit-rcoformation-updates-history.js
@@ -1,0 +1,23 @@
+module.exports = {
+  async up(db) {
+    const collection = db.collection("rcoformations");
+
+    // keep only the last 100 elements in history
+    await collection.updateMany(
+      {},
+      {
+        $push: {
+          updates_history: {
+            $each: [],
+            $slice: -100,
+          },
+        },
+      }
+    );
+  },
+
+  async down() {
+    // can't restore previous state
+    return Promise.resolve("ok");
+  },
+};

--- a/server/src/common/model/schema/rcoFormation.js
+++ b/server/src/common/model/schema/rcoFormation.js
@@ -159,7 +159,8 @@ const rcoFormationsSchema = {
   last_update_at: {
     type: Date,
     default: Date.now,
-    description: "Date de dernières mise à jour",
+    description: "Date de dernière mise à jour",
+    expires: "1y", // mongo will remove the document 1 year after the last update
   },
   converted_to_mna: {
     index: true,

--- a/server/src/jobs/formations/rcoImporter/importer/importer.js
+++ b/server/src/jobs/formations/rcoImporter/importer/importer.js
@@ -392,7 +392,7 @@ class Importer {
       {
         ...rcoFormation,
         ...updateInfo,
-        updates_history,
+        updates_history: updates_history.slice(-100), // keep only the last 100 elements
         last_update_at: Date.now(),
         converted_to_mna: false,
         conversion_error: null,

--- a/server/src/jobs/formations/rcoImporter/importer/importer.js
+++ b/server/src/jobs/formations/rcoImporter/importer/importer.js
@@ -80,11 +80,6 @@ class Importer {
       } else if (updateInfo.published === false) {
         element.published = "Supprimée";
       }
-
-      // const rcoFormation = await RcoFormations.findById(element.mnaId);
-      // const updates_history = rcoFormation.updates_history[rcoFormation.updates_history.length - 1];
-      // element.from = JSON.stringify(updates_history.from);
-      // element.to = JSON.stringify(updates_history.to);
     });
 
     // eslint-disable-next-line no-unused-vars
@@ -297,6 +292,16 @@ class Importer {
         // Some formations has been updated
         if (keys.length !== 0) {
           updated.push(formation);
+        } else {
+          // set last update so that it resets expires for this document
+          await RcoFormation.findOneAndUpdate(
+            {
+              cle_ministere_educatif: formation.cle_ministere_educatif,
+            },
+            {
+              last_update_at: Date.now(),
+            }
+          );
         }
       }
     });


### PR DESCRIPTION
https://trello.com/c/lTkFCn3d/941-clean-données-dhistorisation-garder-1-an-les-formations-archivées-de-rco

- Suppression des formations RCO après 1 an sans mise à jour (et sans arrivée dans le flux)
- Limitation pour garder 100 éléments dans l'historique des mises à jours des formations RCO
