### PR TITLE
feat: published dates

### DIFF
--- a/server/migrations/20220216111515-add-published-dates.js
+++ b/server/migrations/20220216111515-add-published-dates.js
@@ -1,0 +1,47 @@
+const { COMMON_STATUS } = require("../src/constants/status");
+const { findPublishedDate } = require("../src/common/utils/historyUtils");
+
+module.exports = {
+  async up(db) {
+    const collection = db.collection("formations");
+
+    const affelnetCursor = await collection.find({ affelnet_statut: COMMON_STATUS.PUBLIE });
+    for await (const formation of affelnetCursor) {
+      const publishedDate = findPublishedDate(formation, "affelnet");
+      await collection.updateOne(
+        { _id: formation._id },
+        {
+          $set: {
+            affelnet_published_date: publishedDate,
+          },
+        }
+      );
+    }
+
+    const parcoursupCursor = await collection.find({ parcoursup_statut: COMMON_STATUS.PUBLIE });
+    for await (const formation of parcoursupCursor) {
+      const publishedDate = findPublishedDate(formation, "parcoursup");
+      await collection.updateOne(
+        { _id: formation._id },
+        {
+          $set: {
+            parcoursup_published_date: publishedDate,
+          },
+        }
+      );
+    }
+  },
+
+  async down(db) {
+    const collection = db.collection("formations");
+    await collection.updateMany(
+      {},
+      {
+        $unset: {
+          affelnet_published_date: 1,
+          parcoursup_published_date: 1,
+        },
+      }
+    );
+  },
+};

--- a/server/src/common/model/schema/formation/formation.js
+++ b/server/src/common/model/schema/formation/formation.js
@@ -355,6 +355,11 @@ const formationSchema = {
     default: null,
     description: "ids ParcourSup",
   },
+  parcoursup_published_date: {
+    type: Date,
+    default: null,
+    description: 'Date de publication (passage au statut "publié")',
+  },
   affelnet_statut: {
     type: String,
     enum: [
@@ -373,6 +378,11 @@ const formationSchema = {
     default: [],
     description: "Affelnet : historique des statuts",
     noIndex: true,
+  },
+  affelnet_published_date: {
+    type: Date,
+    default: null,
+    description: 'Date de publication (passage au statut "publié")',
   },
   opcos: {
     type: [String],

--- a/server/src/common/model/swaggerSchema/formation.js
+++ b/server/src/common/model/swaggerSchema/formation.js
@@ -35,13 +35,53 @@ module.exports = {
       },
       affelnet_mefs_10: {
         type: "array",
-        items: {},
+        items: {
+          title: "itemOf_affelnet_mefs_10",
+          type: "object",
+          properties: {
+            mef10: {
+              type: "string",
+            },
+            modalite: {
+              title: "modalite",
+              type: "object",
+              properties: {
+                duree: {
+                  type: "string",
+                },
+                annee: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
         default: [],
         description: "Tableau de Code MEF 10 caractères et modalités (filtrés pour Affelnet si applicable)",
       },
       parcoursup_mefs_10: {
         type: "array",
-        items: {},
+        items: {
+          title: "itemOf_parcoursup_mefs_10",
+          type: "object",
+          properties: {
+            mef10: {
+              type: "string",
+            },
+            modalite: {
+              title: "modalite",
+              type: "object",
+              properties: {
+                duree: {
+                  type: "string",
+                },
+                annee: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
         default: [],
         description: "Tableau de Code MEF 10 caractères et modalités (filtrés pour Parcoursup si applicable)",
       },
@@ -337,6 +377,12 @@ module.exports = {
         default: "null",
         description: "ids ParcourSup",
       },
+      parcoursup_published_date: {
+        type: "string",
+        default: "null",
+        description: 'Date de publication (passage au statut "publié")',
+        format: "date-time",
+      },
       affelnet_statut: {
         type: "string",
         enum: [
@@ -355,6 +401,12 @@ module.exports = {
         items: {},
         default: [],
         description: "Affelnet : historique des statuts",
+      },
+      affelnet_published_date: {
+        type: "string",
+        default: "null",
+        description: 'Date de publication (passage au statut "publié")',
+        format: "date-time",
       },
       opcos: {
         type: "array",
@@ -507,7 +559,27 @@ module.exports = {
       },
       bcn_mefs_10: {
         type: "array",
-        items: {},
+        items: {
+          title: "itemOf_bcn_mefs_10",
+          type: "object",
+          properties: {
+            mef10: {
+              type: "string",
+            },
+            modalite: {
+              title: "modalite",
+              type: "object",
+              properties: {
+                duree: {
+                  type: "string",
+                },
+                annee: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
         default: "null",
         description: "BCN : Codes MEF 10 caractères",
       },

--- a/server/src/common/utils/historyUtils.js
+++ b/server/src/common/utils/historyUtils.js
@@ -1,0 +1,26 @@
+const { COMMON_STATUS } = require("../../constants/status");
+
+/**
+ * find last not "publié" from the end and return "publié" date
+ */
+const findPublishedDate = (formation, plateforme) => {
+  // ensure formation is currently published first
+  if (formation[`${plateforme}_statut`] !== COMMON_STATUS.PUBLIE) {
+    return null;
+  }
+
+  const lastIndex = formation[`${plateforme}_statut_history`].length - 1;
+  let publishedDate = formation[`${plateforme}_statut_history`][lastIndex].date;
+  for (let i = lastIndex; i >= 0; i--) {
+    const historyElement = formation[`${plateforme}_statut_history`][i];
+
+    if (historyElement[`${plateforme}_statut`] === COMMON_STATUS.PUBLIE) {
+      publishedDate = historyElement.date;
+    } else {
+      return publishedDate;
+    }
+  }
+  return publishedDate;
+};
+
+module.exports = { findPublishedDate };

--- a/server/src/http/routes/parcoursup.js
+++ b/server/src/http/routes/parcoursup.js
@@ -258,6 +258,7 @@ module.exports = () => {
                   mnaFormationU.parcoursup_statut = from.parcoursup_statut;
                   mnaFormationU.parcoursup_raison_depublication = from.parcoursup_raison_depublication;
                   mnaFormationU.last_update_who = user.email;
+                  mnaFormationU.parcoursup_published_date = null;
                   break;
                 }
               }

--- a/server/src/jobs/affelnet/perimetre/controller.js
+++ b/server/src/jobs/affelnet/perimetre/controller.js
@@ -88,6 +88,24 @@ const run = async () => {
     });
   });
 
+  // ensure published date is set
+  await Formation.updateMany(
+    {
+      affelnet_published_date: null,
+      affelnet_statut: AFFELNET_STATUS.PUBLIE,
+    },
+    { $set: { affelnet_published_date: Date.now() } }
+  );
+
+  // ensure published date is not set
+  await Formation.updateMany(
+    {
+      affelnet_published_date: { $ne: null },
+      affelnet_statut: { $ne: AFFELNET_STATUS.PUBLIE },
+    },
+    { $set: { affelnet_published_date: null } }
+  );
+
   // Push entry in tags history
   await updateTagsHistory("affelnet_statut");
 

--- a/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
+++ b/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
@@ -59,6 +59,7 @@ const copyAffelnetFields = (oldFormation, newFormation) => {
   newFormation.affelnet_code_nature = oldFormation.affelnet_code_nature;
   newFormation.affelnet_secteur = oldFormation.affelnet_secteur;
   newFormation.affelnet_raison_depublication = oldFormation.affelnet_raison_depublication;
+  newFormation.affelnet_published_date = oldFormation.affelnet_published_date;
   return newFormation;
 };
 
@@ -66,6 +67,7 @@ const copyParcoursupFields = (oldFormation, newFormation) => {
   newFormation.parcoursup_statut = oldFormation.parcoursup_statut;
   newFormation.parcoursup_statut_history = oldFormation.parcoursup_statut_history;
   newFormation.parcoursup_raison_depublication = oldFormation.parcoursup_raison_depublication;
+  newFormation.parcoursup_published_date = oldFormation.parcoursup_published_date;
   return newFormation;
 };
 

--- a/server/src/jobs/parcoursup/export/index.js
+++ b/server/src/jobs/parcoursup/export/index.js
@@ -89,6 +89,7 @@ const createFormation = async (formation, email = null) => {
 
     formation.parcoursup_id = response.g_ta_cod;
     formation.parcoursup_statut = PARCOURSUP_STATUS.PUBLIE;
+    formation.parcoursup_published_date = Date.now();
     formation.last_update_at = Date.now();
     formation.last_update_who = `web service Parcoursup${email ? `, sent by ${email}` : ""}`;
     formation.parcoursup_statut_history.push({

--- a/server/src/jobs/parcoursup/perimetre/controller.js
+++ b/server/src/jobs/parcoursup/perimetre/controller.js
@@ -170,6 +170,24 @@ const run = async () => {
     });
   });
 
+  // ensure published date is set
+  await Formation.updateMany(
+    {
+      parcoursup_published_date: null,
+      parcoursup_statut: PARCOURSUP_STATUS.PUBLIE,
+    },
+    { $set: { parcoursup_published_date: Date.now() } }
+  );
+
+  // ensure published date is not set
+  await Formation.updateMany(
+    {
+      parcoursup_published_date: { $ne: null },
+      parcoursup_statut: { $ne: PARCOURSUP_STATUS.PUBLIE },
+    },
+    { $set: { parcoursup_published_date: null } }
+  );
+
   // Push entry in tags history
   await updateTagsHistory("parcoursup_statut");
 

--- a/server/src/logic/controller/reconciliation.js
+++ b/server/src/logic/controller/reconciliation.js
@@ -40,6 +40,9 @@ async function reconciliationAffelnet(formationAffelnet) {
 
     if (formation.affelnet_statut !== AFFELNET_STATUS.NON_PUBLIE) {
       update.affelnet_statut = AFFELNET_STATUS.PUBLIE;
+      if (!formation.affelnet_published_date) {
+        formation.affelnet_published_date = Date.now();
+      }
     }
     update.last_update_at = Date.now();
     await Formation.findOneAndUpdate({ cle_ministere_educatif }, update);

--- a/server/tests/unit/common/utils/historyUtils.test.js
+++ b/server/tests/unit/common/utils/historyUtils.test.js
@@ -1,0 +1,155 @@
+const assert = require("assert");
+const { findPublishedDate } = require("../../../../src/common/utils/historyUtils");
+
+describe(__filename, () => {
+  it("should return null if formation is not published", () => {
+    const formation = {
+      affelnet_statut: "à publier",
+      affelnet_statut_history: [
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-01T04:53:04.743Z"),
+        },
+        {
+          affelnet_statut: "à publier",
+          date: new Date("2022-02-02T03:13:34.469Z"),
+        },
+        {
+          affelnet_statut: "à publier",
+          date: new Date("2022-02-03T05:06:13.157Z"),
+        },
+      ],
+    };
+
+    let result = findPublishedDate(formation, "affelnet");
+    assert.deepStrictEqual(result, null);
+  });
+
+  it("should return first date if  all 'publié'", () => {
+    const formation = {
+      affelnet_statut: "publié",
+      affelnet_statut_history: [
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-01T04:53:04.743Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-02T03:13:34.469Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-03T05:06:13.157Z"),
+        },
+      ],
+    };
+
+    let result = findPublishedDate(formation, "affelnet");
+    assert.deepStrictEqual(result, new Date("2022-02-01T04:53:04.743Z"));
+  });
+
+  it("should find last published date if is the last element", () => {
+    const formation = {
+      affelnet_statut: "publié",
+      affelnet_statut_history: [
+        {
+          affelnet_statut: "hors périmètre",
+          date: new Date("2022-02-01T04:53:04.743Z"),
+        },
+        {
+          affelnet_statut: "à publier",
+          date: new Date("2022-02-02T03:13:34.469Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-03T05:06:13.157Z"),
+        },
+      ],
+    };
+
+    let result = findPublishedDate(formation, "affelnet");
+    assert.deepStrictEqual(result, new Date("2022-02-03T05:06:13.157Z"));
+  });
+
+  it("should find last published date if is not the last element", () => {
+    const formation = {
+      affelnet_statut: "publié",
+      affelnet_statut_history: [
+        {
+          affelnet_statut: "hors périmètre",
+          date: new Date("2022-02-01T04:53:04.743Z"),
+        },
+        {
+          affelnet_statut: "à publier",
+          date: new Date("2022-02-02T03:13:34.469Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-03T05:06:13.157Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-04T05:20:50.577Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-05T06:04:16.935Z"),
+        },
+      ],
+    };
+
+    let result = findPublishedDate(formation, "affelnet");
+    assert.deepStrictEqual(result, new Date("2022-02-03T05:06:13.157Z"));
+  });
+
+  it("should find last published date even if there are multiple publié at different dates", () => {
+    const formation = {
+      affelnet_statut: "publié",
+      affelnet_statut_history: [
+        {
+          affelnet_statut: "hors périmètre",
+          date: new Date("2022-02-01T04:53:04.743Z"),
+        },
+        {
+          affelnet_statut: "à publier",
+          date: new Date("2022-02-02T03:13:34.469Z"),
+        },
+        {
+          affelnet_statut: "à publier",
+          date: new Date("2022-02-03T05:06:13.157Z"),
+        },
+        {
+          affelnet_statut: "à publier",
+          date: new Date("2022-02-04T05:20:50.577Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-05T06:04:16.935Z"),
+        },
+        {
+          affelnet_statut: "hors périmètre",
+          date: new Date("2022-02-06T05:34:39.230Z"),
+        },
+        {
+          affelnet_statut: "hors périmètre",
+          date: new Date("2022-02-07T06:09:25.820Z"),
+        },
+        {
+          affelnet_statut: "hors périmètre",
+          date: new Date("2022-02-07T16:48:08.954Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-07T16:59:23.703Z"),
+        },
+        {
+          affelnet_statut: "publié",
+          date: new Date("2022-02-07T17:07:18.273Z"),
+        },
+      ],
+    };
+
+    let result = findPublishedDate(formation, "affelnet");
+    assert.deepStrictEqual(result, new Date("2022-02-07T16:59:23.703Z"));
+  });
+});

--- a/ui/src/common/components/Search/Search.js
+++ b/ui/src/common/components/Search/Search.js
@@ -163,22 +163,64 @@ export default React.memo(({ location, searchState, context, onReconciliationCar
                     );
                   })}
                 {isBaseFormations && auth?.sub !== "anonymous" && (
-                  <DateRange
-                    componentId="periode"
-                    dataField="periode"
-                    title="Période"
-                    placeholder={{
-                      start: "Date de début",
-                      end: "Date de fin",
-                    }}
-                    numberOfMonths={2}
-                    queryFormat="date"
-                    autoFocusEnd={true}
-                    showClear={true}
-                    showFilter={true}
-                    filterLabel="Période"
-                    URLParams={true}
-                  />
+                  <Flex pt={3}>
+                    <DateRange
+                      componentId="periode"
+                      dataField="periode"
+                      title="Période"
+                      placeholder={{
+                        start: "Date de début",
+                        end: "Date de fin",
+                      }}
+                      numberOfMonths={1}
+                      queryFormat="date"
+                      autoFocusEnd={true}
+                      showClear={true}
+                      showFilter={true}
+                      filterLabel="Période"
+                      URLParams={true}
+                    />
+                  </Flex>
+                )}
+                {isBaseFormations && auth?.sub !== "anonymous" && (
+                  <Flex pt={3}>
+                    <DateRange
+                      componentId="parcoursup_published_date"
+                      dataField="parcoursup_published_date"
+                      title="Date de publication sur Parcoursup"
+                      placeholder={{
+                        start: "Date de début",
+                        end: "Date de fin",
+                      }}
+                      numberOfMonths={1}
+                      queryFormat="date"
+                      autoFocusEnd={true}
+                      showClear={true}
+                      showFilter={true}
+                      filterLabel="Date de publication"
+                      URLParams={true}
+                    />
+                  </Flex>
+                )}
+                {isBaseFormations && auth?.sub !== "anonymous" && (
+                  <Flex pt={3}>
+                    <DateRange
+                      componentId="affelnet_published_date"
+                      dataField="affelnet_published_date"
+                      title="Date de publication sur Affelnet"
+                      placeholder={{
+                        start: "Date de début",
+                        end: "Date de fin",
+                      }}
+                      numberOfMonths={1}
+                      queryFormat="date"
+                      autoFocusEnd={true}
+                      showClear={true}
+                      showFilter={true}
+                      filterLabel="Date de publication"
+                      URLParams={true}
+                    />
+                  </Flex>
                 )}
               </Box>
               <div className="search-results">

--- a/ui/src/common/components/Search/constantsFormations.js
+++ b/ui/src/common/components/Search/constantsFormations.js
@@ -34,6 +34,8 @@ const FILTERS = () => [
   "qualiopi",
   "duree",
   "periode",
+  "parcoursup_published_date",
+  "affelnet_published_date",
 ];
 
 const columnsDefinition = [

--- a/ui/src/common/components/formation/PublishModal.jsx
+++ b/ui/src/common/components/formation/PublishModal.jsx
@@ -73,6 +73,7 @@ const getSubmitBody = ({
     ) {
       body.affelnet_raison_depublication = affelnet_raison_depublication;
       body.affelnet_statut = AFFELNET_STATUS.NON_PUBLIE;
+      body.affelnet_published_date = null;
     }
   }
 
@@ -103,6 +104,7 @@ const getSubmitBody = ({
     ) {
       body.parcoursup_raison_depublication = parcoursup_raison_depublication;
       body.parcoursup_statut = PARCOURSUP_STATUS.NON_PUBLIE;
+      body.parcoursup_published_date = null;
       shouldRemovePsReconciliation = [PARCOURSUP_STATUS.EN_ATTENTE, PARCOURSUP_STATUS.PUBLIE].includes(
         formation.parcoursup_statut
       );

--- a/ui/src/common/components/formation/PublishModal.test.js
+++ b/ui/src/common/components/formation/PublishModal.test.js
@@ -177,6 +177,7 @@ test("should compute submit body when UNpublish affelnet", () => {
     body: {
       affelnet_raison_depublication: "not to be published",
       affelnet_statut: AFFELNET_STATUS.NON_PUBLIE,
+      affelnet_published_date: null,
     },
     shouldRemovePsReconciliation: false,
     shouldRestorePsReconciliation: false,
@@ -298,6 +299,7 @@ test("should compute submit body when UNpublish parcoursup", () => {
 
   expect(result).toEqual({
     body: {
+      parcoursup_published_date: null,
       parcoursup_raison_depublication: "not to be published",
       parcoursup_statut: PARCOURSUP_STATUS.NON_PUBLIE,
     },

--- a/ui/src/locales/helpText.json
+++ b/ui/src/locales/helpText.json
@@ -23,7 +23,9 @@
     "localite": "La donnée “Commune” provient des bases “Carif-Oref”. Si cette information est erronée, merci de le signaler au Carif-Oref de votre région.",
     "code_commune_insee": "La donnée “Code commune” provient des bases “Carif-Oref”. Si cette information est erronée, merci de le signaler au Carif-Oref de votre région.",
     "nom_departement": "La donnée “Département” est déduite du Code postal",
-    "lieu_formation_adresse_computed": "L'adresse est calculée à partir de la géolocalisation. Rapprochez vous de votre Carif-Oref pour préciser cette géolocalisation afin que les jeunes puissent identifier où se situe le lieu de formation."
+    "lieu_formation_adresse_computed": "L'adresse est calculée à partir de la géolocalisation. Rapprochez vous de votre Carif-Oref pour préciser cette géolocalisation afin que les jeunes puissent identifier où se situe le lieu de formation.",
+    "parcoursup_published_date": "Date à laquelle la formation est passée à l'état \"Parcoursup - publié\" dans le catalogue (envoi automatique ou rapprochement des bases Parcoursup et Carif-Oref)",
+    "affelnet_published_date": "Date à laquelle la formation est passée à l'état \"Affelnet - publié\" dans le catalogue (rapprochement des bases Affelnet et Carif-Oref)"
   },
   "etablissement": {
     "raison_sociale": "La donnée “Raison sociale” provient de l’INSEE puis est déduite du SIREN. Si cette information est erronée, merci de leur signaler.",

--- a/ui/src/pages/Etablissement/Etablissement.js
+++ b/ui/src/pages/Etablissement/Etablissement.js
@@ -69,7 +69,7 @@ const Etablissement = ({ etablissement, edition, onEdit, handleChange, handleSub
 
   let creationDate = "";
   try {
-    creationDate = new Date(etablissement.date_creation).toLocaleDateString();
+    creationDate = new Date(etablissement.date_creation).toLocaleDateString("fr-FR");
   } catch (e) {
     console.error("can't display creation date ", etablissement.date_creation);
   }

--- a/ui/src/pages/Formation/Formation.js
+++ b/ui/src/pages/Formation/Formation.js
@@ -165,9 +165,34 @@ const Formation = ({ formation, edition, onEdit, handleChange, handleSubmit, val
               </Text>
             </Box>
           </Box>
-          <Box mb={[0, 0, 16]} px={8}>
+          <Box mb={16} px={8}>
             <OrganismesBlock formation={formation} />
           </Box>
+          {(formation?.affelnet_published_date ?? formation?.parcoursup_published_date) && (
+            <Box mb={16} px={8}>
+              <Heading textStyle="h4" color="grey.800" mb={4}>
+                Autres informations
+              </Heading>
+              {formation?.affelnet_published_date && (
+                <Text mb={4}>
+                  Date de publication sur Affelnet :{" "}
+                  <Text as="span" variant="highlight">
+                    {new Date(formation.affelnet_published_date).toLocaleDateString("fr-FR")}
+                  </Text>{" "}
+                  <InfoTooltip description={helpText.formation.affelnet_published_date} />
+                </Text>
+              )}
+              {formation?.parcoursup_published_date && (
+                <Text mb={4}>
+                  Date de publication sur Parcoursup :{" "}
+                  <Text as="span" variant="highlight">
+                    {new Date(formation.parcoursup_published_date).toLocaleDateString("fr-FR")}
+                  </Text>{" "}
+                  <InfoTooltip description={helpText.formation.parcoursup_published_date} />
+                </Text>
+              )}
+            </Box>
+          )}
         </GridItem>
       </Grid>
     </Box>
@@ -323,6 +348,7 @@ export default ({ match }) => {
                       <Button
                         textStyle="sm"
                         variant="primary"
+                        minW={null}
                         px={8}
                         mt={[8, 8, 0]}
                         onClick={() => {

--- a/ui/src/pages/admin/ReconciliationPs/components/ReconciliationModalHeader.jsx
+++ b/ui/src/pages/admin/ReconciliationPs/components/ReconciliationModalHeader.jsx
@@ -84,9 +84,11 @@ const ReconciliationModalHeader = React.memo(
             if (parcoursup_keep_publish === "true") {
               body.parcoursup_statut = PARCOURSUP_STATUS.PUBLIE;
               body.parcoursup_raison_depublication = null;
+              body.parcoursup_published_date = Date.now();
             } else if (parcoursup_keep_publish === "false") {
               body.parcoursup_raison_depublication = parcoursup_raison_depublication;
               body.parcoursup_statut = PARCOURSUP_STATUS.NON_PUBLIE;
+              body.parcoursup_published_date = null;
             }
 
             const formationsARapprocher = [];

--- a/ui/src/pages/layout/components/AlertMessage.js
+++ b/ui/src/pages/layout/components/AlertMessage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Box, Alert, AlertIcon, AlertTitle, AlertDescription, CloseButton, Text } from "@chakra-ui/react";
+import { Box, Alert, AlertIcon, AlertTitle, AlertDescription, CloseButton, Text, Flex } from "@chakra-ui/react";
 import { _get, _delete } from "../../../common/httpClient";
 import useAuth from "../../../common/hooks/useAuth";
 import { hasAccessTo } from "../../../common/utils/rolesUtils";
@@ -43,11 +43,17 @@ const AlertMessage = () => {
   };
   if (messages.length === 0) return null;
   return (
-    <Box>
-      <Alert status="error">
-        <AlertIcon />
-        <AlertTitle mr={2}>Maintenance : </AlertTitle>
-        <AlertDescription>
+    <Box m={0} fontSize={["omega", "omega", "epsilon"]}>
+      <Alert status="error" flexDirection={["column", "column", "column", "row"]} m={0}>
+        <Flex m={0} p={0}>
+          <Flex m={0}>
+            <AlertIcon boxSize={6} />
+          </Flex>
+          <AlertTitle m={0} p={0}>
+            Maintenance&nbsp;:
+          </AlertTitle>
+        </Flex>
+        <AlertDescription m={0} pl={2}>
           {messages.map((element) => element.enabled && <Text key={element._id}>{element.msg}</Text>)}
         </AlertDescription>
         {auth && hasAccessTo(auth, "page_message_maintenance") && (

--- a/ui/src/pages/layout/components/Header.js
+++ b/ui/src/pages/layout/components/Header.js
@@ -38,15 +38,15 @@ const Header = () => {
   return (
     <>
       <AlertMessage />
-      <Container maxW={"full"} borderBottom={"1px solid"} borderColor={"grey.400"} px={[0, 4]}>
-        <Container maxW="xl" py={[0, 2]} px={[0, 4]}>
+      <Container maxW={"full"} borderBottom={"1px solid"} borderColor={"grey.400"} px={[0, 0, 4]}>
+        <Container maxW="xl" py={[0, 0, 2]} px={[0, 0, 4]}>
           <Flex alignItems="center" color="grey.800">
             {/* Logo */}
-            <Link as={NavLink} to="/" p={[4, 0]}>
+            <Link as={NavLink} to="/" p={[4, 4, 0]}>
               <Logo />
             </Link>
 
-            <Box p={[1, 6]} flex="1">
+            <Box p={[1, 1, 6]} flex="1">
               <Heading as="h6" textStyle="h6">
                 Catalogue des offres de formations en apprentissage
               </Heading>
@@ -65,7 +65,7 @@ const Header = () => {
                 <MenuButton as={Button} variant="pill">
                   <Flex>
                     <AccountFill color={"bluefrance"} mt="0.3rem" boxSize={4} />
-                    <Box display={["none", "block"]} ml={2}>
+                    <Box display={["none", "none", "block"]} ml={2}>
                       <Text color="bluefrance" textStyle="sm">
                         {auth.sub}{" "}
                         <Text color="grey.600" as="span">

--- a/ui/src/pages/layout/components/NavigationMenu.js
+++ b/ui/src/pages/layout/components/NavigationMenu.js
@@ -11,7 +11,7 @@ const NavigationMenu = (props) => {
   const toggle = () => setIsOpen(!isOpen);
 
   return (
-    <NavBarContainer {...props}>
+    <NavBarContainer {...props} position={"relative"}>
       <NavToggle toggle={toggle} isOpen={isOpen} />
       <NavLinks isOpen={isOpen} />
     </NavBarContainer>
@@ -20,7 +20,13 @@ const NavigationMenu = (props) => {
 
 const NavToggle = ({ toggle, isOpen }) => {
   return (
-    <Box display={{ base: "block", md: "none" }} onClick={toggle} py={4}>
+    <Box
+      display={{ base: "block", md: "none" }}
+      onClick={toggle}
+      py={4}
+      position={isOpen ? "absolute" : "relative"}
+      top={0}
+    >
       {isOpen ? <Close boxSize={8} /> : <MenuFill boxSize={8} />}
     </Box>
   );
@@ -32,7 +38,7 @@ const NavItem = ({ children, to = "/", ...rest }) => {
 
   return (
     <Link
-      p={4}
+      p={3}
       as={NavLink}
       to={to}
       color={isActive ? "bluefrance" : "grey.800"}
@@ -53,9 +59,9 @@ const NavLinks = ({ isOpen }) => {
     <Box display={{ base: isOpen ? "block" : "none", md: "block" }} flexBasis={{ base: "100%", md: "auto" }}>
       <Flex
         align="center"
-        justify={["center", "space-between", "flex-end", "flex-end"]}
-        direction={["column", "row", "row", "row"]}
-        pb={[8, 0]}
+        justify={["center", "center", "flex-end", "flex-end"]}
+        direction={["column", "column", "row", "row"]}
+        py={2}
         textStyle="sm"
       >
         <NavItem to="/">Accueil</NavItem>


### PR DESCRIPTION
https://trello.com/c/GVUVtxOk/932-pouvoir-vérifier-les-publié-qui-ont-déjà-été-confirmée-via-date-de-modification-ou-horodatage-avec-possibilité-de-filtrage-par-p

Ajout de la date de publication pour Affelnet & Parcoursup, + filtrage & affichage sur la fiche formation.