### PR TITLE
fix: don't reset status badges for non-qualiopi

### DIFF
--- a/server/src/jobs/affelnet/perimetre/controller.js
+++ b/server/src/jobs/affelnet/perimetre/controller.js
@@ -12,7 +12,6 @@ const run = async () => {
     {
       $or: [
         { affelnet_statut: null },
-        { etablissement_gestionnaire_catalogue_published: false },
         { etablissement_reference_catalogue_published: false },
         { published: false },
         { cfd_outdated: true },

--- a/server/src/jobs/parcoursup/perimetre/controller.js
+++ b/server/src/jobs/parcoursup/perimetre/controller.js
@@ -12,7 +12,6 @@ const run = async () => {
     {
       $or: [
         { parcoursup_statut: null },
-        { etablissement_gestionnaire_catalogue_published: false },
         { etablissement_reference_catalogue_published: false },
         { published: false },
         { cfd_outdated: true },


### PR DESCRIPTION
since non-qualiopi are in "catalogue général" don't reset status badges
https://trello.com/c/i0cysqz5/946-etiquette-affelnet-à-publier-persistante