### PR TITLE
fix: no more filter on rncp for parcoursup

### DIFF
--- a/server/src/jobs/parcoursup/export/index.js
+++ b/server/src/jobs/parcoursup/export/index.js
@@ -10,7 +10,6 @@ const limit = Number(process.env.CATALOGUE_APPRENTISSAGE_PARCOURSUP_LIMIT || 50)
 const filter = {
   parcoursup_statut: PARCOURSUP_STATUS.EN_ATTENTE,
   uai_formation: { $ne: null },
-  rncp_code: { $ne: null },
 };
 
 const select = {
@@ -60,7 +59,7 @@ const formatter = async ({
 
   return {
     user: await findPublishUser(updates_history),
-    rncp: [Number(rncp_code.replace("RNCP", ""))],
+    rncp: rncp_code ? [Number(rncp_code.replace("RNCP", ""))] : [],
     cfd: cfd_entree,
     uai: uai_formation,
     rco: cle_ministere_educatif,

--- a/server/src/jobs/parcoursup/tests/export.test.js
+++ b/server/src/jobs/parcoursup/tests/export.test.js
@@ -140,43 +140,46 @@ describe(__filename, () => {
     assert.strictEqual(countFormations, 8);
   });
 
-  it("should filter only 5 formations", async () => {
+  it("should filter only 6 formations", async () => {
     let cursor = createCursor();
     let index = 0;
     while (await cursor.next()) {
       index += 1;
     }
-    assert.strictEqual(index, 5);
+    assert.strictEqual(index, 6);
   });
 
   it("should sort formations with errors at last", async () => {
     let cursor = createCursor();
     let index = 0;
     for await (const formation of cursor) {
-      if (index < 3) {
+      if (index < 4) {
         assert.strictEqual(formation.parcoursup_error, null);
       } else {
         assert.strictEqual(formation.parcoursup_error, "error ws");
       }
 
       if (index === 0) {
-        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle4");
+        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle2");
       }
       if (index === 1) {
-        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle5");
+        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle4");
       }
       if (index === 2) {
-        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle8");
+        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle5");
       }
       if (index === 3) {
-        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle7");
+        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle8");
       }
       if (index === 4) {
+        assert.strictEqual(formation.cle_ministere_educatif, "12345-cle7");
+      }
+      if (index === 5) {
         assert.strictEqual(formation.cle_ministere_educatif, "12345-cle6");
       }
       index += 1;
     }
-    assert.strictEqual(index, 5);
+    assert.strictEqual(index, 6);
   });
 
   it("should create 1 formation on ps side", async () => {


### PR DESCRIPTION
https://trello.com/c/jFL1cmCI/903-envoyer-les-formations-sans-code-rncp-au-ws-ps