### PR TITLE
fix: merge multi-site trainings on RCO key change

### DIFF
--- a/server/src/jobs/affelnet/coverage.js
+++ b/server/src/jobs/affelnet/coverage.js
@@ -5,7 +5,10 @@ const { runScript } = require("../scriptWrapper");
 const logger = require("../../common/logger");
 const { reconciliationAffelnet } = require("../../logic/controller/reconciliation");
 const { AFFELNET_STATUS } = require("../../constants/status");
-const { findNewFormations, findMultisiteFormations } = require("../formations/rcoConverter/converter/migrationFinder");
+const {
+  findNewFormations,
+  findMultisiteFormationsFromL01,
+} = require("../formations/rcoConverter/converter/migrationFinder");
 const { formation: formatFormation } = require("../../logic/controller/formater");
 const { asyncForEach } = require("../../common/utils/asyncUtils");
 
@@ -35,8 +38,9 @@ const formation = async () => {
             matching: matchingFormation,
           };
 
-          // passer à "publié" toutes les formations d'un multi-site
-          const multisiteFormations = await findMultisiteFormations(
+          // dans le cas où on reçoit une clé en L01 de Affelnet
+          // on passe à "publié" toutes les formations de ce multi-site (si on trouve plusieurs sites)
+          const multisiteFormations = await findMultisiteFormationsFromL01(
             { cle_ministere_educatif: formation.cle_ministere_educatif },
             formatFormation
           );

--- a/server/src/jobs/formations/rcoConverter/converter/converter.js
+++ b/server/src/jobs/formations/rcoConverter/converter/converter.js
@@ -225,8 +225,6 @@ const performConversion = async () => {
   const convertedRcoFormations = [];
 
   // first loop only on published
-  // try to find englobing actions
-  // if found keep data like statut, rapprochement ...
   await paginator(
     RcoFormation,
     {
@@ -235,6 +233,16 @@ const performConversion = async () => {
       select: "+email +etablissement_gestionnaire_courriel +etablissement_formateur_courriel",
     },
     async (rcoFormation) => {
+      // no need to find previous formation if it was already done and created
+      const exists = await Formation.findOne({
+        cle_ministere_educatif: rcoFormation.cle_ministere_educatif,
+        published: true,
+      });
+      if (exists) {
+        return;
+      }
+
+      // try to find old corresponding trainings to retrieve some data
       const oldFormations = await findPreviousFormations(rcoFormation);
 
       // if 0 do nothing : just create as below

--- a/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
+++ b/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
@@ -131,29 +131,6 @@ const extractFlatIdsAction = (id_action) => {
  * @param {Object} [projection={}]
  */
 const findNewFormations = async ({ cle_ministere_educatif }, projection = {}) => {
-  // TODO @EPT : doit-on passer à "publié" toutes les formations d'un multi-site ?
-  // if (cle_ministere_educatif?.endsWith("#L01")) {
-  //   const rootKey = cle_ministere_educatif?.split("#")[0];
-
-  //   const potentialKeys = Array(8)
-  //     .fill(cle_ministere_educatif)
-  //     .map((_value, index) => {
-  //       const siteNumber = index + 2;
-  //       return `${rootKey}${"#L0"}${siteNumber}`;
-  //     });
-
-  //   const previousFormations = await Formation.find({
-  //     cle_ministere_educatif: { $in: potentialKeys },
-  //     published: true,
-  //   })
-  //     .select(projection)
-  //     .lean();
-
-  //   if (previousFormations.length > 0) {
-  //     return previousFormations;
-  //   }
-  // }
-
   const wasCollectedYear = cle_ministere_educatif.substring(10, 11) !== "X";
   if (wasCollectedYear) {
     return [];
@@ -176,6 +153,38 @@ const findNewFormations = async ({ cle_ministere_educatif }, projection = {}) =>
     .lean();
 };
 
+/**
+ * For a given cle_ministere_educatif formation, try to find some Formation in catalogue with different sites
+ *
+ * @param {{cle_ministere_educatif: string}} formation
+ * @param {Object} [projection={}]
+ */
+const findMultisiteFormations = async ({ cle_ministere_educatif }, projection = {}) => {
+  if (cle_ministere_educatif?.endsWith("#L01")) {
+    const rootKey = cle_ministere_educatif?.split("#")[0];
+
+    const potentialKeys = Array(8)
+      .fill(cle_ministere_educatif)
+      .map((_value, index) => {
+        const siteNumber = index + 2;
+        return `${rootKey}${"#L0"}${siteNumber}`;
+      });
+
+    const multisiteFormations = await Formation.find({
+      cle_ministere_educatif: { $in: potentialKeys },
+      published: true,
+    })
+      .select(projection)
+      .lean();
+
+    if (multisiteFormations.length > 0) {
+      return multisiteFormations;
+    }
+  }
+
+  return [];
+};
+
 module.exports = {
   findPreviousFormations,
   copyAffelnetFields,
@@ -186,4 +195,5 @@ module.exports = {
   copyComputedFields,
   copyEditedFields,
   findNewFormations,
+  findMultisiteFormations,
 };

--- a/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
+++ b/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
@@ -4,21 +4,13 @@ const { asyncForEach } = require("../../../../common/utils/asyncUtils");
 /**
  * For a given RcoFormation, try to find some Formation published in catalogue which includes ids_action
  */
-const findPreviousFormations = async ({
-  id_formation,
-  id_certifinfo,
-  id_action,
-  cle_ministere_educatif,
-  etablissement_lieu_formation_code_insee,
-}) => {
-  // FIXME @EPT En pratique, la clé a une longueur fixe : elle fait toujours 49 caractères. Donc la fusion actuelle d’un mono-site qui devient un multi-sites ne fonctionne pas
-  if (cle_ministere_educatif?.includes("-")) {
-    // here merge multi-site / mono-site : check cle_ministere_educatif + code_insee
-    const rootKey = cle_ministere_educatif?.split("-")[0];
+const findPreviousFormations = async ({ id_formation, id_certifinfo, id_action, cle_ministere_educatif }) => {
+  if (!cle_ministere_educatif?.endsWith("#L01")) {
+    // here merge multi-site / mono-site : check cle_ministere_educatif
+    const originalSiteKey = `${cle_ministere_educatif?.split("#")[0]}#L01`;
 
     const previousFormation = await Formation.findOne({
-      cle_ministere_educatif: rootKey,
-      code_commune_insee: etablissement_lieu_formation_code_insee,
+      cle_ministere_educatif: originalSiteKey,
       published: true,
     }).lean();
 
@@ -139,7 +131,28 @@ const extractFlatIdsAction = (id_action) => {
  * @param {Object} [projection={}]
  */
 const findNewFormations = async ({ cle_ministere_educatif }, projection = {}) => {
-  // TODO @EPT here we can receive an old mono-site formations which is now a multi-site in catalog, what is the expected behaviour in that case ?
+  // TODO @EPT : doit-on passer à "publié" toutes les formations d'un multi-site ?
+  // if (cle_ministere_educatif?.endsWith("#L01")) {
+  //   const rootKey = cle_ministere_educatif?.split("#")[0];
+
+  //   const potentialKeys = Array(8)
+  //     .fill(cle_ministere_educatif)
+  //     .map((_value, index) => {
+  //       const siteNumber = index + 2;
+  //       return `${rootKey}${"#L0"}${siteNumber}`;
+  //     });
+
+  //   const previousFormations = await Formation.find({
+  //     cle_ministere_educatif: { $in: potentialKeys },
+  //     published: true,
+  //   })
+  //     .select(projection)
+  //     .lean();
+
+  //   if (previousFormations.length > 0) {
+  //     return previousFormations;
+  //   }
+  // }
 
   const wasCollectedYear = cle_ministere_educatif.substring(10, 11) !== "X";
   if (wasCollectedYear) {

--- a/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
+++ b/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
@@ -165,15 +165,8 @@ const findMultisiteFormationsFromL01 = async ({ cle_ministere_educatif }, projec
   }
 
   const rootKey = cle_ministere_educatif?.split("#")[0];
-  const potentialKeys = Array(98)
-    .fill(cle_ministere_educatif)
-    .map((_value, index) => {
-      const siteNumber = index + 2;
-      return `${rootKey}${"#L"}${`${siteNumber}`.padStart(2, "0")}`;
-    });
-
   const multisiteFormations = await Formation.find({
-    cle_ministere_educatif: { $in: potentialKeys },
+    cle_ministere_educatif: { $ne: cle_ministere_educatif, $regex: new RegExp(`^${rootKey}#`) },
     published: true,
   })
     .select(projection)

--- a/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
+++ b/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
@@ -165,11 +165,11 @@ const findMultisiteFormationsFromL01 = async ({ cle_ministere_educatif }, projec
   }
 
   const rootKey = cle_ministere_educatif?.split("#")[0];
-  const potentialKeys = Array(8)
+  const potentialKeys = Array(98)
     .fill(cle_ministere_educatif)
     .map((_value, index) => {
       const siteNumber = index + 2;
-      return `${rootKey}${"#L0"}${siteNumber}`;
+      return `${rootKey}${"#L"}${`${siteNumber}`.padStart(2, "0")}`;
     });
 
   const multisiteFormations = await Formation.find({

--- a/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
+++ b/server/src/jobs/formations/rcoConverter/converter/migrationFinder.js
@@ -154,35 +154,32 @@ const findNewFormations = async ({ cle_ministere_educatif }, projection = {}) =>
 };
 
 /**
- * For a given cle_ministere_educatif formation, try to find some Formation in catalogue with different sites
+ * For a given formation corresponding to the first site (L01), try to find some Formation in catalogue with different sites
  *
  * @param {{cle_ministere_educatif: string}} formation
  * @param {Object} [projection={}]
  */
-const findMultisiteFormations = async ({ cle_ministere_educatif }, projection = {}) => {
-  if (cle_ministere_educatif?.endsWith("#L01")) {
-    const rootKey = cle_ministere_educatif?.split("#")[0];
-
-    const potentialKeys = Array(8)
-      .fill(cle_ministere_educatif)
-      .map((_value, index) => {
-        const siteNumber = index + 2;
-        return `${rootKey}${"#L0"}${siteNumber}`;
-      });
-
-    const multisiteFormations = await Formation.find({
-      cle_ministere_educatif: { $in: potentialKeys },
-      published: true,
-    })
-      .select(projection)
-      .lean();
-
-    if (multisiteFormations.length > 0) {
-      return multisiteFormations;
-    }
+const findMultisiteFormationsFromL01 = async ({ cle_ministere_educatif }, projection = {}) => {
+  if (!cle_ministere_educatif?.endsWith("#L01")) {
+    return [];
   }
 
-  return [];
+  const rootKey = cle_ministere_educatif?.split("#")[0];
+  const potentialKeys = Array(8)
+    .fill(cle_ministere_educatif)
+    .map((_value, index) => {
+      const siteNumber = index + 2;
+      return `${rootKey}${"#L0"}${siteNumber}`;
+    });
+
+  const multisiteFormations = await Formation.find({
+    cle_ministere_educatif: { $in: potentialKeys },
+    published: true,
+  })
+    .select(projection)
+    .lean();
+
+  return multisiteFormations;
 };
 
 module.exports = {
@@ -195,5 +192,5 @@ module.exports = {
   copyComputedFields,
   copyEditedFields,
   findNewFormations,
-  findMultisiteFormations,
+  findMultisiteFormationsFromL01,
 };

--- a/server/src/jobs/formations/rcoConverter/tests/migrationFinder.test.js
+++ b/server/src/jobs/formations/rcoConverter/tests/migrationFinder.test.js
@@ -2,7 +2,12 @@ const assert = require("assert");
 const { Formation } = require("../../../../common/model/index");
 const { connectToMongoForTests, cleanAll } = require("../../../../../tests/utils/testUtils.js");
 const { asyncForEach } = require("../../../../common/utils/asyncUtils");
-const { findPreviousFormations, copyComputedFields, findNewFormations } = require("../converter/migrationFinder");
+const {
+  findPreviousFormations,
+  copyComputedFields,
+  findNewFormations,
+  findMultisiteFormationsFromL01,
+} = require("../converter/migrationFinder");
 
 const sampleData = [
   {
@@ -76,6 +81,30 @@ const sampleData = [
     published: true,
     annee: "3",
   },
+  {
+    cfd: "11",
+    cle_ministere_educatif: "106401P01115010559410002250105594100022-57631#L02",
+    published: true,
+    annee: "1",
+  },
+  {
+    cfd: "12",
+    cle_ministere_educatif: "100357P01211886090770005518860907700055-17415#L01",
+    published: true,
+    annee: "1",
+  },
+  {
+    cfd: "13",
+    cle_ministere_educatif: "100357P01211886090770005518860907700055-17415#L02",
+    published: true,
+    annee: "1",
+  },
+  {
+    cfd: "14",
+    cle_ministere_educatif: "100357P01211886090770005518860907700055-17415#L03",
+    published: true,
+    annee: "1",
+  },
 ];
 
 describe(__filename, () => {
@@ -91,11 +120,6 @@ describe(__filename, () => {
 
     after(async () => {
       await cleanAll();
-    });
-
-    it("should have inserted sample data", async () => {
-      const count = await Formation.countDocuments({});
-      assert.strictEqual(count, 10);
     });
 
     it("should find 1 Formation", async () => {
@@ -260,6 +284,51 @@ describe(__filename, () => {
       );
 
       assert.deepStrictEqual(formations, [{ cfd: "8" }]);
+    });
+  });
+
+  describe("findMultisiteFormationsFromL01", () => {
+    before(async () => {
+      // Connection to test collection
+      await connectToMongoForTests();
+      await Formation.deleteMany({});
+
+      // insert sample data in DB
+      await asyncForEach(sampleData, async (training) => await new Formation(training).save());
+    });
+
+    after(async () => {
+      await cleanAll();
+    });
+
+    it("should find 0 Formation", async () => {
+      let formations = await findMultisiteFormationsFromL01({
+        cle_ministere_educatif: "106401P01115010559410002250105594100022",
+      });
+
+      assert.strictEqual(formations.length, 0);
+
+      formations = await findMultisiteFormationsFromL01({
+        cle_ministere_educatif: "106401P01115010559410002250105594110022-57631#L01",
+      });
+
+      assert.strictEqual(formations.length, 0);
+    });
+
+    it("should find 1 Formation", async () => {
+      const formations = await findMultisiteFormationsFromL01({
+        cle_ministere_educatif: "106401P01115010559410002250105594100022-57631#L01",
+      });
+
+      assert.strictEqual(formations.length, 1);
+    });
+
+    it("should find 2 Formations", async () => {
+      const formations = await findMultisiteFormationsFromL01({
+        cle_ministere_educatif: "100357P01211886090770005518860907700055-17415#L01",
+      });
+
+      assert.strictEqual(formations.length, 2);
     });
   });
 });

--- a/server/src/jobs/formations/rcoConverter/tests/migrationFinder.test.js
+++ b/server/src/jobs/formations/rcoConverter/tests/migrationFinder.test.js
@@ -153,6 +153,33 @@ describe(__filename, () => {
       assert.strictEqual(formations.length, 1);
       assert.strictEqual(formations[0].cfd, "7");
     });
+
+    it("Multisite - should find 0 Formation", async () => {
+      const formations = await findPreviousFormations({
+        cle_ministere_educatif: "106101P01135010559410002250105594100022-88001#L01",
+        id_formation: "",
+        id_certifinfo: "",
+        id_action: "",
+      });
+
+      assert.strictEqual(formations.length, 0);
+    });
+
+    it("Multisite - should find 1 Formation for L02", async () => {
+      const formations = await findPreviousFormations({
+        cle_ministere_educatif: "106101P01135010559410002250105594100022-76001#L02",
+      });
+
+      assert.strictEqual(formations.length, 1);
+    });
+
+    it("Multisite - should find 1 Formation for L03", async () => {
+      const formations = await findPreviousFormations({
+        cle_ministere_educatif: "106101P01135010559410002250105594100022-76001#L03",
+      });
+
+      assert.strictEqual(formations.length, 1);
+    });
   });
 
   describe("copyComputedFields", () => {

--- a/server/src/logic/controller/reconciliation.js
+++ b/server/src/logic/controller/reconciliation.js
@@ -1,9 +1,9 @@
 const { Formation } = require("../../common/model");
 const { AFFELNET_STATUS } = require("../../constants/status");
 
-async function reconciliationAffelnet(formationAffelnet) {
-  let { code_nature, etablissement_type, code_mef, matching_mna_formation, libelle_mnemonique } = formationAffelnet;
-  let { cle_ministere_educatif } = matching_mna_formation[0];
+async function reconciliationAffelnet(formationAffelnet, match) {
+  let { code_nature, etablissement_type, code_mef, libelle_mnemonique } = formationAffelnet;
+  let { cle_ministere_educatif } = match;
 
   // pass through some data for Affelnet
   const formation = await Formation.findOne(

--- a/server/src/logic/controller/reconciliation.js
+++ b/server/src/logic/controller/reconciliation.js
@@ -2,8 +2,8 @@ const { Formation } = require("../../common/model");
 const { AFFELNET_STATUS } = require("../../constants/status");
 
 async function reconciliationAffelnet(formationAffelnet, match) {
-  let { code_nature, etablissement_type, code_mef, libelle_mnemonique } = formationAffelnet;
-  let { cle_ministere_educatif } = match;
+  const { code_nature, etablissement_type, code_mef, libelle_mnemonique } = formationAffelnet;
+  const { cle_ministere_educatif } = match;
 
   // pass through some data for Affelnet
   const formation = await Formation.findOne(


### PR DESCRIPTION
https://trello.com/c/BU3h6420/967-changement-de-cléme-gestion-des-mono-site-multi-site

Question en cours pour la gestion de l'import de formations Affelnet devenues multi-site entre temps.
Réponse de @Anne-Becquet : 
> ah oui alors, donc se sont les 3 qui doivent être publiés, car sinon on envoie qu'une seule formation pour un CFA académique par exemple avec 1 seul UAI alors que potentiellement il faut en envoyer N. Je crois qu'Affelnet ne gère qu'un seul UAI mais peut créer des UAI lieux de formations si la DEPP les refuse. ...

TODO : 
- [x] tests multi-site affelnet import

~~DRAFT en attente de la réponse sur le nombre de sites possible (cf. mail Marc / Adeline)~~ Débloqué en gérant jusqu'à 99 lieux différents pour une même racine de clé.