### PR TITLE
fix: session cookie is not sent when requests come from another domain

### DIFF
--- a/server/src/http/server.js
+++ b/server/src/http/server.js
@@ -100,6 +100,7 @@ module.exports = async (components, verbose = true) => {
       cookie: {
         secure: config.env === "dev" ? false : true,
         maxAge: config.env === "dev" ? null : 30 * 24 * 60 * 60 * 1000,
+        sameSite: "strict", // prevent csrf attack @see https://auth0.com/blog/cross-site-request-forgery-csrf/
       },
     })
   );


### PR DESCRIPTION
To prevent csrf attacks
@see https://auth0.com/blog/cross-site-request-forgery-csrf/ &
https://cwe.mitre.org/data/definitions/1275.html &
https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/Set-Cookie/SameSite