### PR TITLE
fix: ndjson apis

### DIFF
--- a/server/src/http/routes/etablissement.js
+++ b/server/src/http/routes/etablissement.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const Joi = require("joi");
-const { oleoduc, transformIntoJSON, transformData } = require("oleoduc");
+const { oleoduc, transformIntoJSON } = require("oleoduc");
 const tryCatch = require("../middlewares/tryCatchMiddleware");
 const { sendJsonStream } = require("../../common/utils/httpUtils");
 const { paginate } = require("../../common/utils/mongooseUtils");
@@ -118,11 +118,7 @@ module.exports = () => {
 
       let json = JSON.parse(query);
 
-      let stream = oleoduc(
-        Etablissement.find(json).limit(limit).cursor(),
-        transformData((etablissement) => `${JSON.stringify(etablissement)}\n`)
-      );
-
+      const stream = oleoduc(Etablissement.find(json).limit(limit).cursor(), transformIntoJSON());
       return sendJsonStream(stream, res);
     })
   );

--- a/server/src/http/routes/formation.js
+++ b/server/src/http/routes/formation.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const Joi = require("joi");
-const { oleoduc, transformData } = require("oleoduc");
+const { oleoduc, transformIntoJSON } = require("oleoduc");
 const tryCatch = require("../middlewares/tryCatchMiddleware");
 const { Formation } = require("../../common/model");
 const { mnaFormationUpdater } = require("../../logic/updaters/mnaFormationUpdater");
@@ -257,11 +257,7 @@ module.exports = () => {
 
     const selector = JSON.parse(select);
 
-    let stream = oleoduc(
-      Formation.find(filter, selector).limit(limit).cursor(),
-      transformData((formation) => `${JSON.stringify(formation)}\n`)
-    );
-
+    const stream = oleoduc(Formation.find(filter, selector).limit(limit).cursor(), transformIntoJSON());
     return sendJsonStream(stream, res);
   });
 

--- a/server/tests/integration/http/etablissement-test.js
+++ b/server/tests/integration/http/etablissement-test.js
@@ -68,8 +68,8 @@ httpTests(__filename, ({ startServer }) => {
     const response = await httpClient.get("/api/v1/entity/etablissements.ndjson?limit=2");
 
     strictEqual(response.status, 200);
-    let etablissements = response.data.split("\n").filter((e) => e);
+    const etablissements = response.data;
     strictEqual(etablissements.length, 2);
-    deepStrictEqual(JSON.parse(etablissements[0]).uai, "0010856A");
+    deepStrictEqual(etablissements[0].uai, "0010856A");
   });
 });

--- a/server/tests/integration/http/formation.test.js
+++ b/server/tests/integration/http/formation.test.js
@@ -22,8 +22,8 @@ httpTests(__filename, ({ startServer }) => {
     const response = await httpClient.get("/api/v1/entity/formations.ndjson?limit=2");
 
     assert.strictEqual(response.status, 200);
-    let formations = response.data.split("\n").filter((e) => e);
+    const formations = response.data;
     assert.strictEqual(formations.length, 2);
-    assert.deepStrictEqual(JSON.parse(formations[0]).cfd, "123456789");
+    assert.deepStrictEqual(formations[0].cfd, "123456789");
   });
 });


### PR DESCRIPTION
So that one may call :
```js
const response = await fetch("https://catalogue.apprentissage.beta.gouv.fr/api/v1/entity/formations.ndjson");
const data = await response.json();
...
```