### PR TITLE
chore: enable $regex & $options on /formations API

### DIFF
--- a/server/src/common/utils/sanitizeUtils.js
+++ b/server/src/common/utils/sanitizeUtils.js
@@ -17,6 +17,8 @@ const SAFE_OPERATORS = [
   "$elemMatch",
   "$all",
   "$size",
+  "$regex",
+  "$options",
 ];
 
 const deepRenameKeys = (obj, keysMap) =>


### PR DESCRIPTION
https://trello.com/c/Vf4aj1OQ/1104-v5172-akto-ne-peut-plus-accéder-à-lopérateur-regex-de-lapi-catalogue